### PR TITLE
Added License Informations for the current known ESA Licensed Images

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -22,3 +22,16 @@ The contents of this document, along with all other legal aspects pertaining to 
 		- Attribution: Which is done [hereby](https://hyperioncantos.fandom.com/wiki/Shrike)
 		- ShareAlike: Since we have not made any modifications or alterations to the file, you are free to use it in its original form, in accordance with the aforementioned license. Simply locate the corresponding file within the project's folder structure.
 
+- ./resources/images/cmbr.jpg
+    - License: ESA standard license
+    - License Requirements:
+        - Credit: ESA and the Planck Collaboration
+        - ESA images may not be used to state or imply the endorsement by ESA or any ESA employee of a commercial product, process or service, or used in any other manner that might mislead.
+        - If ESA images are to be used in advertising or any commercial promotion, layout and copy must be submitted to ESA beforehand for approval to: spaceinimages@esa.int
+
+- ./resources/images/jwst-neptune.jpg
+    - License: ESA standard license
+    - License Requirements:
+        - Credit: ESA and the Planck Collaboration
+        - ESA images may not be used to state or imply the endorsement by ESA or any ESA employee of a commercial product, process or service, or used in any other manner that might mislead.
+        - If ESA images are to be used in advertising or any commercial promotion, layout and copy must be submitted to ESA beforehand for approval to: spaceinimages@esa.int


### PR DESCRIPTION
Added License Informations for the current known ESA Licensed Images:
/resources/images/cmbr.jpg
/resources/images/jwst-neptune.jpg

Used: https://www.esa.int/ESA_Multimedia/Copyright_Notice_Images

## NO LEGAL ADVICE ##